### PR TITLE
Add missing fontconfig lib for Travis and Docker

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -86,12 +86,15 @@ else (WIN32)
 	PKG_CHECK_MODULES(SPEEX REQUIRED speexdsp)
 endif (WIN32)
 
-# Include libdl for dlopen
 if (UNIX)
+	# Include libdl for dlopen
 	set(DLLIB dl)
+
+	# FontConfig for TrueType fonts.
+	PKG_CHECK_MODULES(FONTCONFIG REQUIRED fontconfig)
 endif (UNIX)
 
-INCLUDE_DIRECTORIES(${SDL2_INCLUDE_DIRS} ${LIBCURL_INCLUDE_DIRS} ${JANSSON_INCLUDE_DIRS} ${SPEEX_INCLUDE_DIRS})
+INCLUDE_DIRECTORIES(${SDL2_INCLUDE_DIRS} ${LIBCURL_INCLUDE_DIRS} ${JANSSON_INCLUDE_DIRS} ${SPEEX_INCLUDE_DIRS} ${FONTCONFIG_INCLUDE_DIRS})
 
 LINK_DIRECTORIES(${SDL2_LIBRARY_DIRS} ${JANSSON_LIBRARY_DIRS} ${LIBCURL_LIBRARY_DIRS})
 
@@ -161,11 +164,6 @@ if (UNIX)
 		list(APPEND RCT2_SECTIONS "${CMAKE_BINARY_DIR}/openrct2_data_section.o" "${CMAKE_BINARY_DIR}/openrct2_text_section.o")
 		set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Wl,-T,\"${CMAKE_CURRENT_SOURCE_DIR}/distribution/linux/ld_script.xc\"")
 	endif (APPLE)
-
-	# FontConfig for TrueType fonts.
-	find_path(FONTCONFIG_INCLUDE_DIR fontconfig/fontconfig.h)
-	find_library(FONTCONFIG_LIBRARY NAMES fontconfig)
-	TARGET_LINK_LIBRARIES(${PROJECT} ${FONTCONFIG_LIBRARY})
 endif (UNIX)
 
 # install into ${CMAKE_INSTALL_PREFIX}/bin/
@@ -174,7 +172,7 @@ endif (UNIX)
 # libopenrct2.dll -> openrct2.dll
 set_target_properties(${PROJECT} PROPERTIES PREFIX "")
 
-TARGET_LINK_LIBRARIES(${PROJECT} ${SDL2_LIBRARIES} ${ORCTLIBS_LIB} ${HTTPLIBS} ${NETWORKLIBS} ${SPEEX_LIBRARIES} ${DLLIB} ${RCT2_SECTIONS})
+TARGET_LINK_LIBRARIES(${PROJECT} ${SDL2_LIBRARIES} ${ORCTLIBS_LIB} ${HTTPLIBS} ${NETWORKLIBS} ${SPEEX_LIBRARIES} ${DLLIB} ${RCT2_SECTIONS} ${FONTCONFIG_LIBRARIES})
 
 # CMake does not allow specifying a dependency chain which includes built-in
 # targets, like `install`, so we have to trick it and execute dependency ourselves.

--- a/dockerfiles/32bit/Dockerfile
+++ b/dockerfiles/32bit/Dockerfile
@@ -26,4 +26,4 @@ RUN pacman -R --noconfirm gcc
 RUN yes | pacman -S gcc-libs-multilib
 RUN pacman -S --noconfirm gcc-multilib
 USER travis
-RUN yaourt -S --noconfirm lib32-jansson lib32-curl lib32-sdl2 lib32-sdl2_ttf lib32-speex
+RUN yaourt -S --noconfirm lib32-jansson lib32-curl lib32-sdl2 lib32-sdl2_ttf lib32-speex lib32-fontconfig

--- a/scripts/linux/install.sh
+++ b/scripts/linux/install.sh
@@ -171,7 +171,7 @@ elif [[ $(uname) == "Linux" ]]; then
 			"linux")
 				sudo dpkg --add-architecture i386
 				sudo apt-get update
-				sudo apt-get install --no-install-recommends -y --force-yes cmake libsdl2-dev:i386 libsdl2-ttf-dev:i386 gcc-4.8 pkg-config:i386 g++-4.8-multilib gcc-4.8-multilib libjansson-dev:i386 libspeex-dev:i386 libspeexdsp-dev:i386 libcurl4-openssl-dev:i386 libcrypto++-dev:i386 clang
+				sudo apt-get install --no-install-recommends -y --force-yes cmake libsdl2-dev:i386 libsdl2-ttf-dev:i386 gcc-4.8 pkg-config:i386 g++-4.8-multilib gcc-4.8-multilib libjansson-dev:i386 libspeex-dev:i386 libspeexdsp-dev:i386 libcurl4-openssl-dev:i386 libcrypto++-dev:i386 clang libfontconfig1-dev:i386 libfreetype6-dev:i386 libpng-dev:i386
 				download https://launchpad.net/ubuntu/+archive/primary/+files/libjansson4_2.7-1ubuntu1_i386.deb libjansson4_2.7-1ubuntu1_i386.deb
 				download https://launchpad.net/ubuntu/+archive/primary/+files/libjansson-dev_2.7-1ubuntu1_i386.deb libjansson-dev_2.7-1ubuntu1_i386.deb
 				sudo dpkg -i libjansson4_2.7-1ubuntu1_i386.deb


### PR DESCRIPTION
This fixes native Travis builds.

You have to fix mingw yourself.

Docker will not update until the dockerfile is merged, which we can possibly extract and merge earlier, so the build would pass.
