### PR TITLE
Fix memory leaks in font selection for Linux

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -3,6 +3,7 @@
 - Feature: Add displaying of frames per second (FPS).
 - Feature: Changing the number of trains no longer requires retesting.
 - Feature: Add SI units as a new measurement system for distance / speed.
+- Feature: Update alternative font selection mechanism for all platforms.
 - Fix: [#2126] Ferris Wheels set to "backward rotation" stop working (original
 bug)
 - Fix: [#2449] Turning off Day/Night Circle while it is night doesn't reset back to day


### PR DESCRIPTION
Add some logging too, in particular warning when no font was found.

I tried finding a way of figuring out if the font was a substitute or not, but couldn't find one, we'll have to trust fontconfig blindly.
